### PR TITLE
Update README.md to mention vim version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Make the undo region apparent!
 
 ## Dependency
+
+Vim 7.4.1685+ (or, neovim 0.2.0+)
+
 `diff` command (https://www.gnu.org/software/diffutils/) is required to use this plugin.
 
 ```vim


### PR DESCRIPTION
Current vim compatibility is 7.4.1685+, as matchstrpos() is being used.