### PR TITLE
Error for too long change undo

### DIFF
--- a/autoload/highlightedundo.vim
+++ b/autoload/highlightedundo.vim
@@ -271,7 +271,10 @@ function! s:get_seq_of_curhead_parent(undotree) abort "{{{
   return -1
 endfunction "}}}
 function! s:getchanged(before, after) abort "{{{
-  if empty(a:before) || empty(a:after)
+  " XXX: Check matching strictly upto this char length (for performance reason)
+  let matchlen = 200
+
+  if empty(a:before) || empty(a:after) || len(a:before) > matchlen || len(a:after) > matchlen
     let changedbefore = [a:before, 0, strlen(a:before)]
     let changedafter = [a:after, 0, strlen(a:after)]
     return [changedbefore, changedafter]


### PR DESCRIPTION
In too long change, it gets an error.

#### How to Repro

```vim
" Create 80 count of `.` x 1000 lines
:norm 80a.
yy
999p

" Join them into one line
:1
<Shift-v>G
gJ

" Redo to 1000 lines <= Error happens
u
```

#### Error

```
function highlightedundo#undo[3]..<SNR>147_common[7]..<SNR>147_parsediff[19]..<SNR>147_Diff[19]..<SNR>147_subdifflist_change[1]..<SNR>147_getchanged の処理中にエラーが検出されました:
行    8:
E339: パターンが長過ぎます (Too long pattern)
function highlightedundo#undo[3]..<SNR>147_common[7]..<SNR>147_parsediff[19]..<SNR>147_Diff[19]..<SNR>147_subdifflist_change の処理中にエラーが検出されました:
行    1:
E714: リスト型が必要です (Need a list type)
function highlightedundo#undo[3]..<SNR>147_common[7]..<SNR>147_parsediff[19]..<SNR>147_Diff の処理中にエラーが検出されました:
行   19:
E714: リスト型が必要です (Need a list type)
```

----

This happens in calling `matchend()` with too long pattern (see E339 error above).

So, shorten too long pattern.
