### PR TITLE
Introduce fast_mode

### DIFF
--- a/autoload/highlightedundo.vim
+++ b/autoload/highlightedundo.vim
@@ -4,6 +4,7 @@ set cpoptions&vim
 let g:highlightedundo#highlight_mode = get(g:, 'highlightedundo#highlight_mode', 1)
 let g:highlightedundo#highlight_duration_delete = get(g:, 'highlightedundo#highlight_duration_delete', 200)
 let g:highlightedundo#highlight_duration_add = get(g:, 'highlightedundo#highlight_duration_add', 500)
+let g:highlightedundo#fast_mode = get(g:, 'highlightedundo#fast_mode', v:true)
 
 let s:TEMPBEFORE = ''
 let s:TEMPAFTER = ''

--- a/autoload/highlightedundo/highlight.vim
+++ b/autoload/highlightedundo/highlight.vim
@@ -144,6 +144,19 @@ endfunction "}}}
 " for scheduled-quench "{{{
 let s:quench_table = {}
 function! s:quench(id) abort  "{{{
+  if g:highlightedundo#fast_mode
+    call setmatches(filter(getmatches(), 'v:val.group !~# ''^Highlightedundo\(Add\|Change\|Delete\)$'''))
+    let l:id = v:null
+    for l:id in map(keys(s:quench_table), 'str2nr(v:val)')
+      call timer_stop(l:id)
+    endfor
+    unlet! l:id
+    let s:quench_table = {}
+  else
+    return s:quench_(a:id)
+  endif
+endfunction "}}}
+function! s:quench_(id) abort  "{{{
   let options = s:shift_options()
   let highlight = s:get(a:id)
   try
@@ -157,7 +170,7 @@ function! s:quench(id) abort  "{{{
     endif
     return 1
   finally
-    unlet s:quench_table[a:id]
+    unlet! s:quench_table[a:id]
     call timer_stop(a:id)
     call s:restore_options(options)
     redraw

--- a/autoload/highlightedundo/highlight.vim
+++ b/autoload/highlightedundo/highlight.vim
@@ -150,6 +150,14 @@ endfunction "}}}
 
 " for scheduled-quench "{{{
 let s:quench_table = {}
+
+if g:highlightedundo#fast_mode
+  augroup highlightedundo-clear-highlight
+    autocmd!
+    autocmd WinLeave * call s:quench(-1)
+  augroup END
+endif
+
 function! s:quench(id) abort  "{{{
   if g:highlightedundo#fast_mode
     call setmatches(filter(getmatches(), 'v:val.group !~# ''^Highlightedundo\(Add\|Change\|Delete\)$'''))


### PR DESCRIPTION
This script is slow in removing highlights.

So, on timer fired, remove all `Highlightedundo{Add,Delete,Change}` highlights at a time.

Also introduced a switch for this mode as `g:highlightedundo#fast_mode`.
