### PR TITLE
Ignore `s:parsediff()` error to complete the expected undo / redo command

### DIFF
--- a/autoload/highlightedundo.vim
+++ b/autoload/highlightedundo.vim
@@ -83,7 +83,11 @@ function! s:common(count, command, countercommand) abort
     let range_before = s:highlight_range(g:highlightedundo#highlight_extra_lines)
     call winrestview(view)
   endtry
-  let difflist = s:parsediff(hunks, before, after, range_before, range_after)
+  try
+    let difflist = s:parsediff(hunks, before, after, range_before, range_after)
+  catch
+    let difflist = []
+  endtry
 
   let originalcursor = s:hidecursor()
   try


### PR DESCRIPTION
Especially in hex <=> bin conversion using external `xxd` command,
it may fail to parse diff in undo / redo highlighting,
and abort there with leaving the text unchanged.

In such case, shouldn't it just do the expected undo / redo operation skipping highlighting?

Repro
--------------------------------------------------------------------------------

```bash
# Create test input file: hex text of 00 to FF.
% seq 0 255 | xargs -n1 printf '%02X\n' > test.txt
```

```vim
:e ++bin test.txt
:%!xxd -r -ps           " Decode hex text into bin.
u                       " Undo, and raise the error below.
```

```vim
Error detected while processing function <lambda>4[1]..<SNR>122_common[24]..<SNR>122_parsediff[48]..<SNR>122_add_changes:
line   16:
E684: List index out of range: 2
```
